### PR TITLE
Make sure the handle’s position is used for drag position

### DIFF
--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -307,13 +307,13 @@
 		dragStart: function(e)
 		{
 			var mouse    = this.mouse,
-				target   = $(e.target),
+				target   = $(e.target).closest('.'+this.options.handleClass),
 				dragItem = target.closest(this.options.itemNodeName);
 
 			this.placeEl.css('height', dragItem.height());
 
-			mouse.offsetX = e.offsetX !== undefined ? e.offsetX : e.pageX - target.offset().left;
-			mouse.offsetY = e.offsetY !== undefined ? e.offsetY : e.pageY - target.offset().top;
+			mouse.offsetX = e.pageX !== undefined ? e.pageX - target.offset().left : e.offsetX;
+			mouse.offsetY = e.pageY !== undefined ? e.pageY - target.offset().top : e.offsetY;
 			mouse.startX = mouse.lastX = e.pageX;
 			mouse.startY = mouse.lastY = e.pageY;
 


### PR DESCRIPTION
Fixes an issue where a handle with other subelements gets clicked and the subtree appears to snap to the mouse position rather than simply being lifted in place.
